### PR TITLE
Catching errors in "shared"

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ module.exports = function (input, callback) {
       image.width, image.height
     )
 
-    callback(null, shared(canvas)(image))
+    try {
+      callback(null, shared(canvas)(image))
+    }
+    catch (e) {
+      callback(e)
+    }
   })
 }


### PR DESCRIPTION
callback calls "shared(canvas)" which may throw errors in case of corrupt data. This way we can return an error as well and avoid the crash.
