### PR TITLE
Create canvas only when `data` is executed.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,3 @@
-var canvas = document.createElement('canvas')
-
 module.exports = get
 module.exports.data = data
 
@@ -16,6 +14,7 @@ function get (src, cb) {
 }
 
 function data (img) {
+  var canvas = document.createElement('canvas')
   var ctx = canvas.getContext('2d')
   canvas.width = img.width
   canvas.height = img.height


### PR DESCRIPTION
Hi Michael,

I'm having an issue where the reference to `document` on line 1 of `browser.js` is causing a server-side render to fail.

The code of this module is bundled as part as another package, and that package is ran in a node environment. Because there is a reference to `document` at the global scope, the code is executed and a canvas element is attempted to be created. Moving the variable inside the `data` method alleviates the issue.

Would you consider accepting this change?

Thanks!